### PR TITLE
Add license to layer restrictions

### DIFF
--- a/iso_19115_template.xml
+++ b/iso_19115_template.xml
@@ -175,7 +175,7 @@
                     </gmd:useConstraints>
                     <gmd:otherConstraints>
                         <gco:CharacterString>
-                            licensed under $ISO19115_LICENSE
+                            $ISO19115_LICENSE
                         </gco:CharacterString>
                     </gmd:otherConstraints>
                 </gmd:MD_LegalConstraints>

--- a/iso_19115_template.xml
+++ b/iso_19115_template.xml
@@ -169,12 +169,16 @@
                 </gmd:MD_Keywords>
             </gmd:descriptiveKeywords>
             <gmd:resourceConstraints>
-                <gmd:MD_Constraints>
-                    <gmd:useLimitation>
-                        <gco:CharacterString>$ISO19115_LICENSE
+                <gmd:MD_LegalConstraints>
+                    <gmd:useConstraints>
+                        <gmd:MD_RestrictionCode codeSpace="ISOTC211/19115" codeList="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_RestrictionCode" codeListValue="license">license</gmd:MD_RestrictionCode>
+                    </gmd:useConstraints>
+                    <gmd:otherConstraints>
+                        <gco:CharacterString>
+                            licensed under $ISO19115_LICENSE
                         </gco:CharacterString>
-                    </gmd:useLimitation>
-                </gmd:MD_Constraints>
+                    </gmd:otherConstraints>
+                </gmd:MD_LegalConstraints>
             </gmd:resourceConstraints>
             <gmd:language>
                 <gmd:LanguageCode

--- a/metadata_utilities.py
+++ b/metadata_utilities.py
@@ -89,7 +89,8 @@ def generate_iso_metadata(project_definition=None):
     template_replacements = copy.copy(get_defaults())
 
     # create runtime based replacement values
-    template_replacements['ISO19115_TODAY_DATETIME'] = time.strftime("%Y-%m-%dT%H:%M:%SZ")
+    template_replacements['ISO19115_TODAY_DATETIME'] = time.strftime(
+        "%Y-%m-%dT%H:%M:%SZ")
     if project_definition is not None:
         if DEBUG:
             print project_definition
@@ -133,7 +134,8 @@ def generate_iso_metadata(project_definition=None):
 
 
 def write_iso_metadata_file(xml_filename, project_definition=None):
-    """Make a valid ISO 19115 XML file using the values of defaults.get_defaults
+    """
+    Make a valid ISO 19115 XML file using the values of defaults.get_defaults
 
     This method will create a file based on the iso_19115_template.py template
     The $placeholders there will be replaced by the values returned from

--- a/metadata_utilities.py
+++ b/metadata_utilities.py
@@ -117,9 +117,9 @@ def generate_iso_metadata(project_definition=None):
             template_replacements['ISO19115_EMAIL'] = ''
         try:
             template_replacements['ISO19115_LICENSE'] = \
-                project_definition['license']
+                'licensed under ' + project_definition['license']
         except KeyError:
-            template_replacements[''] = ''
+            template_replacements['ISO19115_LICENSE'] = ''
         try:
             template_replacements['$ISO19115_URL'] = \
                 project_definition['$ISO19115_URL']

--- a/metadata_utilities.py
+++ b/metadata_utilities.py
@@ -120,7 +120,7 @@ def generate_iso_metadata(project_definition=None):
             template_replacements['ISO19115_LICENSE'] = \
                 'licensed under ' + project_definition['license']
         except KeyError:
-            template_replacements['ISO19115_LICENSE'] = ''
+            template_replacements['ISO19115_LICENSE'] = 'no license specified'
         try:
             template_replacements['$ISO19115_URL'] = \
                 project_definition['$ISO19115_URL']

--- a/svir.py
+++ b/svir.py
@@ -1282,7 +1282,8 @@ class Svir:
             license_txt = '%s (%s)' % (license_name, license_url)
             project_definition['license'] = license_txt
             project_definition['svir_plugin_version'] = SVIR_PLUGIN_VERSION
-
+            if DEBUG:
+                print 'xml_file:', xml_file
             write_iso_metadata_file(xml_file,
                                     project_definition)
             metadata_dialog = UploadMetadataDialog(


### PR DESCRIPTION
Partially addressing https://bugs.launchpad.net/oq-svir/+bug/1409725
Note: unfortunately, the current version of Geonode does not put the license into a "license" metadata field, but into the "other restrictions" field. We can merge the current solution anyway, and wait for the next version of Geonode for further changes.