### PR TITLE
Force selecting the field containing the zone label, before uploading to the Platform

### DIFF
--- a/svir.py
+++ b/svir.py
@@ -1421,9 +1421,11 @@ class Svir:
         # convert bytes to MB
         file_size_mb = file_size_mb / 1024 / 1024
 
-        dlg = UploadSettingsDialog(file_size_mb)
+        dlg = UploadSettingsDialog(file_size_mb, self.iface)
         if dlg.exec_():
             project_definition['title'] = dlg.ui.title_le.text()
+            zone_label_field = dlg.ui.zone_label_field_cbx.currentText()
+            project_definition['zone_label_field'] = zone_label_field
 
             license_name = dlg.ui.license_cbx.currentText()
             license_idx = dlg.ui.license_cbx.currentIndex()

--- a/transformation_dialog.py
+++ b/transformation_dialog.py
@@ -103,6 +103,7 @@ class TransformationDialog(QDialog):
                 self.ui.layer_cbx.currentIndex()]
         reload_attrib_cbx(self.ui.attrib_cbx,
                           self.selected_layer,
+                          False,
                           NUMERIC_FIELD_TYPES)
         if self.ui.attrib_cbx.count():
             self.ok_button.setEnabled(True)

--- a/ui/ui_upload_settings.py
+++ b/ui/ui_upload_settings.py
@@ -2,7 +2,7 @@
 
 # Form implementation generated from reading ui file 'ui/ui_upload_settings.ui'
 #
-# Created: Wed Dec 24 16:05:28 2014
+# Created: Fri Mar  6 11:24:15 2015
 #      by: PyQt4 UI code generator 4.10.4
 #
 # WARNING! All changes made in this file will be lost!
@@ -41,6 +41,12 @@ class Ui_UploadSettingsDialog(object):
         self.title_le = QtGui.QLineEdit(UploadSettingsDialog)
         self.title_le.setObjectName(_fromUtf8("title_le"))
         self.formLayout.setWidget(0, QtGui.QFormLayout.FieldRole, self.title_le)
+        self.label = QtGui.QLabel(UploadSettingsDialog)
+        self.label.setObjectName(_fromUtf8("label"))
+        self.formLayout.setWidget(1, QtGui.QFormLayout.LabelRole, self.label)
+        self.zone_label_field_cbx = QtGui.QComboBox(UploadSettingsDialog)
+        self.zone_label_field_cbx.setObjectName(_fromUtf8("zone_label_field_cbx"))
+        self.formLayout.setWidget(1, QtGui.QFormLayout.FieldRole, self.zone_label_field_cbx)
         self.verticalLayout.addLayout(self.formLayout)
         self.gridLayout = QtGui.QGridLayout()
         self.gridLayout.setObjectName(_fromUtf8("gridLayout"))
@@ -74,6 +80,7 @@ class Ui_UploadSettingsDialog(object):
         UploadSettingsDialog.setWindowTitle(_translate("UploadSettingsDialog", "Upload Settings", None))
         self.head_msg_lbl.setText(_translate("UploadSettingsDialog", "The active layer will be uploaded to the Openquake Platform", None))
         self.label_4.setText(_translate("UploadSettingsDialog", "Project title", None))
+        self.label.setText(_translate("UploadSettingsDialog", "Zone labels field", None))
         self.label_6.setText(_translate("UploadSettingsDialog", "License", None))
         self.license_info_btn.setText(_translate("UploadSettingsDialog", "Info", None))
         self.confirm_chk.setText(_translate("UploadSettingsDialog", "I confirm I have read the license conditions", None))

--- a/ui/ui_upload_settings.ui
+++ b/ui/ui_upload_settings.ui
@@ -36,6 +36,16 @@
      <item row="0" column="1">
       <widget class="QLineEdit" name="title_le"/>
      </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Zone labels field</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QComboBox" name="zone_label_field_cbx"/>
+     </item>
     </layout>
    </item>
    <item>

--- a/upload_settings_dialog.py
+++ b/upload_settings_dialog.py
@@ -47,7 +47,7 @@ class UploadSettingsDialog(QDialog):
     licenses. The user must click on a confirmation checkbox, before the
     uploading of the layer can be started.
     """
-    def __init__(self, upload_size):
+    def __init__(self, upload_size, iface):
         QDialog.__init__(self)
         # Set up the user interface from Designer.
         self.ui = Ui_UploadSettingsDialog()
@@ -60,14 +60,31 @@ class UploadSettingsDialog(QDialog):
                     % upload_size)
         self.ui.head_msg_lbl.setText(head_msg)
         self.ui.title_le.setText(DEFAULTS['ISO19115_TITLE'])
+        zonal_layer_fields = list(iface.activeLayer().dataProvider().fields())
+        # if no field is selected, whe should not allow uploading
+        self.zone_label_field_is_specified = False
+        self.ui.zone_label_field_cbx.addItem(None)
+        self.ui.zone_label_field_cbx.addItems(
+            [field.name() for field in zonal_layer_fields])
         for license, link in LICENSES:
             self.ui.license_cbx.addItem(license, link)
         self.ui.license_cbx.setCurrentIndex(
             self.ui.license_cbx.findText(DEFAULT_LICENSE[0]))
 
+    def set_ok_button(self):
+        self.ok_button.setEnabled(
+            self.zone_label_field_is_specified
+            and self.ui.confirm_chk.isChecked())
+
+    @pyqtSlot(str)
+    def on_zone_label_field_cbx_currentIndexChanged(self):
+        zone_label_field = self.ui.zone_label_field_cbx.currentText()
+        self.zone_label_field_is_specified = zone_label_field != ''
+        self.set_ok_button()
+
     @pyqtSlot(int)
     def on_confirm_chk_stateChanged(self):
-        self.ok_button.setEnabled(self.ui.confirm_chk.isChecked())
+        self.set_ok_button()
 
     @pyqtSlot()
     def on_license_info_btn_clicked(self):

--- a/upload_settings_dialog.py
+++ b/upload_settings_dialog.py
@@ -30,6 +30,7 @@ from PyQt4.QtGui import (QDialog,
                          QDesktopServices)
 from ui.ui_upload_settings import Ui_UploadSettingsDialog
 from defaults import DEFAULTS
+from utils import reload_attrib_cbx
 
 LICENSES = (
     ('CC0', 'http://creativecommons.org/about/cc0'),
@@ -60,12 +61,12 @@ class UploadSettingsDialog(QDialog):
                     % upload_size)
         self.ui.head_msg_lbl.setText(head_msg)
         self.ui.title_le.setText(DEFAULTS['ISO19115_TITLE'])
-        zonal_layer_fields = list(iface.activeLayer().dataProvider().fields())
+
         # if no field is selected, whe should not allow uploading
         self.zone_label_field_is_specified = False
-        self.ui.zone_label_field_cbx.addItem(None)  # empty first item
-        self.ui.zone_label_field_cbx.addItems(
-            [field.name() for field in zonal_layer_fields])
+        reload_attrib_cbx(
+            self.ui.zone_label_field_cbx, iface.activeLayer(), True)
+
         for license, link in LICENSES:
             self.ui.license_cbx.addItem(license, link)
         self.ui.license_cbx.setCurrentIndex(

--- a/upload_settings_dialog.py
+++ b/upload_settings_dialog.py
@@ -63,7 +63,7 @@ class UploadSettingsDialog(QDialog):
         zonal_layer_fields = list(iface.activeLayer().dataProvider().fields())
         # if no field is selected, whe should not allow uploading
         self.zone_label_field_is_specified = False
-        self.ui.zone_label_field_cbx.addItem(None)
+        self.ui.zone_label_field_cbx.addItem(None)  # empty first item
         self.ui.zone_label_field_cbx.addItems(
             [field.name() for field in zonal_layer_fields])
         for license, link in LICENSES:
@@ -79,7 +79,7 @@ class UploadSettingsDialog(QDialog):
     @pyqtSlot(str)
     def on_zone_label_field_cbx_currentIndexChanged(self):
         zone_label_field = self.ui.zone_label_field_cbx.currentText()
-        self.zone_label_field_is_specified = zone_label_field != ''
+        self.zone_label_field_is_specified = (zone_label_field != '')
         self.set_ok_button()
 
     @pyqtSlot(int)

--- a/utils.py
+++ b/utils.py
@@ -134,15 +134,19 @@ def reload_layers_in_cbx(combo, layer_types=None, skip_layer_ids=None):
             combo.addItem(l.name())
 
 
-def reload_attrib_cbx(combo, layer, *valid_field_types):
+def reload_attrib_cbx(
+        combo, layer, prepend_empty_item=False, *valid_field_types):
     """
     Load attributes of a layer into a combobox. Can filter by field data type.
-    the additional filter can be NUMERIC_FIELD_TYPES, TEXTUAL_FIELD_TYPES, ...
+    the optional filter can be NUMERIC_FIELD_TYPES, TEXTUAL_FIELD_TYPES, ...
+    if no filter is specified all fields are returned
 
     :param combo: The combobox to be repopulated
     :type combo: QComboBox
     :param layer: The QgsVectorLayer from where the fields are read
     :type layer: QgsVectorLayer
+    :param prepend_empty_item: if to prepend an empty item to the combo
+    :type layer: Bool
     :param *valid_field_types: multiple tuples containing types
     :type *valid_field_types: tuple, tuple, ...
     """
@@ -155,6 +159,10 @@ def reload_attrib_cbx(combo, layer, *valid_field_types):
     # populate combo box with field names taken by layers
     dp = layer.dataProvider()
     fields = list(dp.fields())
+
+    if prepend_empty_item:
+        combo.addItem(None)
+
     for field in fields:
         # add if in field_types
         if not field_types or field.typeName() in field_types:


### PR DESCRIPTION
Before this change, after uploading a project to the Platform, a second user couldn't know which of the available layer's fields contains the zone labels used by the layer's creator. This PR forces the user to specify such field from a combobox, before proceeding with the upload. Such field gets saved in `project_definition['zone_label_field']`.
Instead of this approach, we could implement different solutions, but I'm not able to figure out any better one. For instance, we could save what zone id field was used when (and only if!) performing "loss aggregation by zone", and set such field as the default selection. In any case, the field might possibly be a numeric attribute, not so easily usable as a "label" to be displayed in Ben's charts in the web viewer. Therefore I believe it's reasonable to let the user assume the responsibility to decide, right before uploading.
NOTE: What needs to change on the web viewer, if this PR gets merged? I think, anyway, the user should be able to select a different field to be used to display labels on the charts, using the combobox that Ben has implemented (and that shouldn't be dismissed). The web viewer should use by default the `zone_label_field` specified in the project definition, unless the user explicitly selects a different field.