### PR TITLE
Fix corner case in which the project definition is defined in the qgis project, but it's empty

### DIFF
--- a/svir.py
+++ b/svir.py
@@ -251,7 +251,7 @@ class Svir:
         # it returns a tuple, with the returned value and a boolean indicating
         # if such property is available
         resp = QgsProject.instance().readEntry('svir', 'project_definitions')
-        if resp[1] is True:
+        if resp[1] and resp[0]:
             self.project_definitions = json.loads(resp[0])
         else:
             self.project_definitions = {}

--- a/svir.py
+++ b/svir.py
@@ -250,9 +250,10 @@ class Svir:
         # get project_definitions from the project's properties
         # it returns a tuple, with the returned value and a boolean indicating
         # if such property is available
-        resp = QgsProject.instance().readEntry('svir', 'project_definitions')
-        if resp[1] and resp[0]:
-            self.project_definitions = json.loads(resp[0])
+        project_definitions_str, is_available = \
+            QgsProject.instance().readEntry('svir', 'project_definitions')
+        if is_available and project_definitions_str:
+            self.project_definitions = json.loads(project_definitions_str)
         else:
             self.project_definitions = {}
         if DEBUG:


### PR DESCRIPTION
This is a one-line fix, but important. It solves a very annoying issue that might occur when the qgis project contains an empty project definition. In that case, the plugin attempts to parse the project definition's json, which is an empty string, so it raises an exception.
I added a check to avoid that.