### PR TITLE
Handle the case in which multiple project definitions are available for a single project

### DIFF
--- a/metadata_utilities.py
+++ b/metadata_utilities.py
@@ -97,7 +97,10 @@ def generate_iso_metadata(project_definition=None):
         if DEBUG:
             print project_definition
         template_replacements['SVIR_PROJECT_DEFINITION'] = '<![CDATA[%s]]>' % \
-            json.dumps(project_definition)
+            json.dumps(project_definition,
+                       sort_keys=False,
+                       indent=2,
+                       separators=(',', ': '))
         try:
             template_replacements['ISO19115_TITLE'] = \
                 project_definition['title']

--- a/svir.py
+++ b/svir.py
@@ -299,6 +299,7 @@ class Svir:
             self.registered_actions["transform_attribute"].setEnabled(True)
             self.sync_proj_def()
             proj_def = self.project_definitions[self.current_layer.id()]
+            # TODO:Let the user choose one of the available project definitions
             if isinstance(proj_def, list):
                 proj_def = proj_def[-1]
             self.registered_actions["upload"].setEnabled(proj_def is not None)
@@ -653,6 +654,7 @@ class Svir:
         current_layer_id = self.iface.activeLayer().id()
         try:
             project_definition = self.project_definitions[current_layer_id]
+            # TODO:Let the user choose one of the available project definitions
             if isinstance(project_definition, list):
                 project_definition = project_definition[-1]
         except KeyError:
@@ -678,6 +680,7 @@ class Svir:
         current_layer_id = self.current_layer.id()
         try:
             project_definition = self.project_definitions[current_layer_id]
+            # TODO:Let the user choose one of the available project definitions
             if isinstance(project_definition, list):
                 project_definition = project_definition[-1]
         except KeyError:
@@ -1041,6 +1044,7 @@ class Svir:
         xml_file = file_stem + '.xml'
 
         project_definition = self.project_definitions[self.current_layer.id()]
+        # TODO: Let the user choose one of the available project definitions
         if isinstance(project_definition, list):
             project_definition = project_definition[-1]
 

--- a/svir.py
+++ b/svir.py
@@ -299,6 +299,8 @@ class Svir:
             self.registered_actions["transform_attribute"].setEnabled(True)
             self.sync_proj_def()
             proj_def = self.project_definitions[self.current_layer.id()]
+            if isinstance(proj_def, list):
+                proj_def = proj_def[-1]
             self.registered_actions["upload"].setEnabled(proj_def is not None)
         except KeyError:
             # self.project_definitions[self.current_layer.id()] is not defined
@@ -651,12 +653,14 @@ class Svir:
         current_layer_id = self.iface.activeLayer().id()
         try:
             project_definition = self.project_definitions[current_layer_id]
+            if isinstance(project_definition, list):
+                project_definition = project_definition[-1]
         except KeyError:
             project_definition = PROJECT_TEMPLATE
             self.update_proj_def(current_layer_id, project_definition)
         old_project_definition = copy.deepcopy(project_definition)
 
-        dlg = SetProjectDefinitionDialog(self.iface, project_definition, )
+        dlg = SetProjectDefinitionDialog(self.iface, project_definition)
         if dlg.exec_():
             project_definition = dlg.project_definition
             self.update_actions_status()
@@ -674,6 +678,8 @@ class Svir:
         current_layer_id = self.current_layer.id()
         try:
             project_definition = self.project_definitions[current_layer_id]
+            if isinstance(project_definition, list):
+                project_definition = project_definition[-1]
         except KeyError:
             project_definition = PROJECT_TEMPLATE
             self.update_proj_def(current_layer_id, project_definition)
@@ -1035,6 +1041,8 @@ class Svir:
         xml_file = file_stem + '.xml'
 
         project_definition = self.project_definitions[self.current_layer.id()]
+        if isinstance(project_definition, list):
+            project_definition = project_definition[-1]
 
         QgsVectorFileWriter.writeAsVectorFormat(
             self.current_layer,

--- a/weight_data_dialog.py
+++ b/weight_data_dialog.py
@@ -128,7 +128,10 @@ class WeightDataDialog(QDialog):
     @pyqtProperty(str)
     def json_str(self):
         #This method gets exposed to JS thanks to @pyqtProperty(str)
-        return json.dumps(self.project_definition)
+        return json.dumps(self.project_definition,
+                          sort_keys=False,
+                          indent=2,
+                          separators=(',', ': '))
 
     @pyqtProperty(str)
     def DEFAULT_OPERATOR(self):


### PR DESCRIPTION
In that case, for now, we just use the most recent project definition.
In a later PR we will need to allow the user to select one of the available project definitions.
We will also need to have an additional workflow, to update one of the projects on the platform, adding only a new project definition to that (as the web viewer now does).

This PR also explicitly sets the parameters in json.dumps, in order to make the project definition format consistent in all cases, including the server-side occurrences.