### PR TITLE
If the (stripped) hostname ends with '/', remove it

### DIFF
--- a/settings_dialog.py
+++ b/settings_dialog.py
@@ -72,8 +72,11 @@ class SettingsDialog(QtGui.QDialog, Ui_SettingsDialog):
         Store the options into the user's stored session info.
         """
         mySettings = QtCore.QSettings()
-        mySettings.setValue('svir/platform_hostname',
-                            self.ui.hostnameEdit.text())
+        # if the hostname ends with '/', remove it
+        hostname = self.ui.hostnameEdit.text().strip()
+        if hostname.endswith('/'):
+            hostname = hostname[:-1]
+        mySettings.setValue('svir/platform_hostname', hostname)
         mySettings.setValue('svir/platform_username',
                             self.ui.usernameEdit.text())
         mySettings.setValue('svir/platform_password',

--- a/settings_dialog.py
+++ b/settings_dialog.py
@@ -72,10 +72,8 @@ class SettingsDialog(QtGui.QDialog, Ui_SettingsDialog):
         Store the options into the user's stored session info.
         """
         mySettings = QtCore.QSettings()
-        # if the hostname ends with '/', remove it
-        hostname = self.ui.hostnameEdit.text().strip()
-        if hostname.endswith('/'):
-            hostname = hostname[:-1]
+        # if the (stripped) hostname ends with '/', remove it
+        hostname = self.ui.hostnameEdit.text().strip().rstrip('/')
         mySettings.setValue('svir/platform_hostname', hostname)
         mySettings.setValue('svir/platform_username',
                             self.ui.usernameEdit.text())


### PR DESCRIPTION
In the OQ-Platform connection settings, the user might set a host like `https://platform-dev.openquake.org/`, ending with `/`. Before this PR, this produced some weird behaviors, because the host was recognized, but the `/` interfered with the platform's API. In order to avoid this, we strip the hostname and remove the ending `/` if present.