### PR TITLE
Better manage platform login exceptions

### DIFF
--- a/import_sv_data.py
+++ b/import_sv_data.py
@@ -30,7 +30,10 @@ import csv
 from qgis.gui import QgsMessageBar
 
 from third_party.requests import Session
-from third_party.requests.exceptions import ConnectionError
+from third_party.requests.exceptions import (ConnectionError,
+                                             InvalidSchema,
+                                             MissingSchema
+                                             )
 
 from utils import (SvNetworkError, platform_login, get_credentials,
                    WaitCursorManager, tr)
@@ -51,10 +54,14 @@ def get_loggedin_downloader(iface):
         with WaitCursorManager(msg, iface):
             sv_downloader.login(username, password)
         return sv_downloader
-    except (SvNetworkError, ConnectionError) as e:
+    except (SvNetworkError, ConnectionError,
+            InvalidSchema, MissingSchema) as e:
+        err_msg = str(e)
+        if isinstance(e, InvalidSchema):
+            err_msg += ' (you could try prepending http:// or https://)'
         iface.messageBar().pushMessage(
             tr("Login Error"),
-            tr(str(e)),
+            tr(err_msg),
             level=QgsMessageBar.CRITICAL)
         return None
 

--- a/utils.py
+++ b/utils.py
@@ -242,7 +242,9 @@ def platform_login(host, username, password, session):
                                 data={
                                     "username": username,
                                     "password": password
-                                })
+                                },
+                                timeout=10,
+                                )
     if session_resp.status_code != 200:  # 200 means successful:OK
         error_message = ('Unable to get session for login: %s' %
                          session_resp.content)


### PR DESCRIPTION
There were some corner cases in which the login failed and the plugin broke instead of displaying an error message in the QGIS message bar. I also set a timeout of 10 seconds for the login, otherwise the server could not respond for a long time (also blocking the GUI).