### PR TITLE
Recalculate indices after selecting a different project definition

### DIFF
--- a/calculate_utils.py
+++ b/calculate_utils.py
@@ -47,13 +47,17 @@ def calculate_svi(iface, current_layer, project_definition):
     add an SVI attribute to the current layer
     """
     try:
+        # get the social vulnerability index node, starting from the tree root
         svi_node = project_definition['children'][1]
         themes = svi_node['children']
         # calculate the SVI only if all themes contain at least one indicator
         for theme in themes:
             indicators = theme['children']
     except KeyError:
-        # FIXME Decide what to do here
+        msg = ('Something is missing in the project definition.'
+               ' The SVI could not be calculated')
+        iface.messageBar().pushMessage(tr('Warning'), tr(msg),
+                                       level=QgsMessageBar.WARNING)
         return None, None
     try:
         themes_operator = svi_node['operator']
@@ -232,7 +236,10 @@ def calculate_ri(iface, current_layer, project_definition):
         # calculate the RI only if there is at least one risk indicator
         indicators = ri_node['children']
     except KeyError:
-        # FIXME Decide what to do here
+        msg = ('Something is missing in the project definition.'
+               ' The RI could not be calculated')
+        iface.messageBar().pushMessage(tr('Warning'), tr(msg),
+                                       level=QgsMessageBar.WARNING)
         return None, None
     try:
         ri_operator = ri_node['operator']

--- a/calculate_utils.py
+++ b/calculate_utils.py
@@ -46,9 +46,8 @@ def calculate_svi(iface, current_layer, project_definition):
     """
     add an SVI attribute to the current layer
     """
-
-    svi_node = project_definition['children'][1]
     try:
+        svi_node = project_definition['children'][1]
         themes = svi_node['children']
         # calculate the SVI only if all themes contain at least one indicator
         for theme in themes:
@@ -227,9 +226,9 @@ def calculate_ri(iface, current_layer, project_definition):
     """
     add an RI attribute to the current layer
     """
-    # get the risk index node, starting from the tree root
-    ri_node = project_definition['children'][0]
     try:
+        # get the risk index node, starting from the tree root
+        ri_node = project_definition['children'][0]
         # calculate the RI only if there is at least one risk indicator
         indicators = ri_node['children']
     except KeyError:

--- a/svir.py
+++ b/svir.py
@@ -678,6 +678,8 @@ class Svir:
                 self.iface.activeLayer().id(),
                 project_definitions,
                 select_proj_def_dlg.selected_idx)
+            self.recalculate_indexes(
+                project_definitions[select_proj_def_dlg.selected_idx])
             self.redraw_ir_layer(
                 project_definitions[select_proj_def_dlg.selected_idx])
 
@@ -770,7 +772,10 @@ class Svir:
         return svi_attr_id, ri_attr_id, iri_attr_id
 
     def is_svi_renderable(self, proj_def):
-        svi_node = proj_def['children'][1]
+        try:
+            svi_node = proj_def['children'][1]
+        except KeyError:
+            return False
         # check that that the svi_node has a corresponding field
         if 'field' not in svi_node:
             return False
@@ -788,7 +793,10 @@ class Svir:
         return True
 
     def is_ri_renderable(self, proj_def):
-        ri_node = proj_def['children'][0]
+        try:
+            ri_node = proj_def['children'][0]
+        except KeyError:
+            return False
         # check that that the ri_node has a corresponding field
         if 'field' not in ri_node:
             return False


### PR DESCRIPTION
Also avoid the plugin to break when the selected project definition is invalid (in such case, the indices are not recalculated and the style is not updated)