### PR TITLE
Pre-populate the title field before uploading a project to the platform

### DIFF
--- a/svir.py
+++ b/svir.py
@@ -1024,6 +1024,10 @@ class Svir:
         selected_idx = layer_dict['selected_idx']
         proj_defs = layer_dict['proj_defs']
         project_definition = proj_defs[selected_idx]
+        if 'title' in project_definition:
+            project_title = project_definition['title']
+        else:
+            project_title = None
 
         QgsVectorFileWriter.writeAsVectorFormat(
             self.current_layer,
@@ -1038,7 +1042,7 @@ class Svir:
         # convert bytes to MB
         file_size_mb = file_size_mb / 1024 / 1024
 
-        dlg = UploadSettingsDialog(file_size_mb, self.iface)
+        dlg = UploadSettingsDialog(file_size_mb, self.iface, project_title)
         if dlg.exec_():
             project_definition['title'] = dlg.ui.title_le.text()
             zone_label_field = dlg.ui.zone_label_field_cbx.currentText()

--- a/upload_settings_dialog.py
+++ b/upload_settings_dialog.py
@@ -48,7 +48,7 @@ class UploadSettingsDialog(QDialog):
     licenses. The user must click on a confirmation checkbox, before the
     uploading of the layer can be started.
     """
-    def __init__(self, upload_size, iface):
+    def __init__(self, upload_size, iface, project_title=None):
         QDialog.__init__(self)
         # Set up the user interface from Designer.
         self.ui = Ui_UploadSettingsDialog()
@@ -60,7 +60,10 @@ class UploadSettingsDialog(QDialog):
                     '(About %s MB of data will be transmitted)'
                     % upload_size)
         self.ui.head_msg_lbl.setText(head_msg)
-        self.ui.title_le.setText(DEFAULTS['ISO19115_TITLE'])
+        if project_title:
+            self.ui.title_le.setText(project_title)
+        else:
+            self.ui.title_le.setText(DEFAULTS['ISO19115_TITLE'])
 
         # if no field is selected, whe should not allow uploading
         self.zone_label_field_is_specified = False


### PR DESCRIPTION
In the "upload project to platform" dialog, if the project already has a title, use it instead of the default one.