### PR TITLE
Enable to add a new project definition to a project already present on the platform

### DIFF
--- a/projects_manager_dialog.py
+++ b/projects_manager_dialog.py
@@ -71,11 +71,16 @@ class ProjectsManagerDialog(QDialog):
                                             'proj_defs': []}
         else:
             self.project_definitions = {'selected_idx': None, 'proj_defs': []}
-        for proj_def in self.project_definitions['proj_defs']:
-            if 'platform_layer_id' in proj_def:
-                self.platform_layer_id = proj_def['platform_layer_id']
-            if 'zone_label_field' in proj_def:
-                self.zone_label_field = proj_def['zone_label_field']
+        # All project definitions are linked to the same layer on the platform
+        # So we can get such information from the first project_definition
+        first_proj_def = self.project_definitions['proj_defs'][0]
+        if 'platform_layer_id' in first_proj_def:
+            self.platform_layer_id = first_proj_def['platform_layer_id']
+        # The zone label field might be different for different project
+        # definitions, but it sounds reasonable to suggest the first one in the
+        # combobox and to allow the user to change it if needed
+        if 'zone_label_field' in first_proj_def:
+            self.zone_label_field = first_proj_def['zone_label_field']
 
     def populate_proj_def_cbx(self):
         self.ui.proj_def_cbx.clear()

--- a/projects_manager_dialog.py
+++ b/projects_manager_dialog.py
@@ -53,6 +53,8 @@ class ProjectsManagerDialog(QDialog):
         self.project_definitions = None  # it will store the project
                                          # definitions for the active layer
         self.selected_idx = None  # index of the selected project definition
+        self.platform_layer_id = None  # id of the geonode layer on platform
+        self.zone_label_field = None  # field containing zone identifiers
         self.get_project_definitions()
         self.populate_proj_def_cbx()
 
@@ -69,6 +71,11 @@ class ProjectsManagerDialog(QDialog):
                                             'proj_defs': []}
         else:
             self.project_definitions = {'selected_idx': None, 'proj_defs': []}
+        for proj_def in self.project_definitions['proj_defs']:
+            if 'platform_layer_id' in proj_def:
+                self.platform_layer_id = proj_def['platform_layer_id']
+            if 'zone_label_field' in proj_def:
+                self.zone_label_field = proj_def['zone_label_field']
 
     def populate_proj_def_cbx(self):
         self.ui.proj_def_cbx.clear()
@@ -93,6 +100,10 @@ class ProjectsManagerDialog(QDialog):
     def add_proj_def(self, title):
         proj_def_template = PROJECT_TEMPLATE
         proj_def_template['title'] = title
+        if self.platform_layer_id:
+            proj_def_template['platform_layer_id'] = self.platform_layer_id
+        if self.zone_label_field:
+            proj_def_template['zone_label_field'] = self.zone_label_field
         self.project_definitions['proj_defs'].append(proj_def_template)
         self.project_definitions['selected_idx'] = len(
             self.project_definitions['proj_defs']) - 1

--- a/projects_manager_dialog.py
+++ b/projects_manager_dialog.py
@@ -73,6 +73,8 @@ class ProjectsManagerDialog(QDialog):
             self.project_definitions = {'selected_idx': None, 'proj_defs': []}
         # All project definitions are linked to the same layer on the platform
         # So we can get such information from the first project_definition
+        # NOTE: If the "upload" button is enabled, we should always have at
+        # least one project definition defined for the active layer
         first_proj_def = self.project_definitions['proj_defs'][0]
         if 'platform_layer_id' in first_proj_def:
             self.platform_layer_id = first_proj_def['platform_layer_id']

--- a/svir.py
+++ b/svir.py
@@ -69,6 +69,8 @@ from process_layer import ProcessLayer
 
 import resources_rc  # pylint: disable=W0611  # NOQA
 
+from third_party.requests.sessions import Session
+
 from select_input_layers_dialog import SelectInputLayersDialog
 from attribute_selection_dialog import AttributeSelectionDialog
 from transformation_dialog import TransformationDialog
@@ -86,7 +88,11 @@ from utils import (tr,
                    clear_progress_message_bar,
                    SvNetworkError, ask_for_download_destination,
                    files_exist_in_destination, confirm_overwrite,
-                   count_heading_commented_lines)
+                   count_heading_commented_lines,
+                   platform_login,
+                   get_credentials,
+                   update_platform_project,
+                   )
 from shared import (SVIR_PLUGIN_VERSION,
                     DEBUG,
                     PROJECT_TEMPLATE,
@@ -642,6 +648,9 @@ class Svir:
             # project definition
             if not isinstance(project_definitions, list):
                 project_definitions = [project_definitions]
+            for proj_def in project_definitions:
+                if 'platform_layer_id' not in proj_def:
+                    proj_def['platform_layer_id'] = dlg.layer_id
             self.update_proj_defs(layer.id(), project_definitions)
             self.update_actions_status()
             # in case of multiple project definitions, let the user select one
@@ -1033,10 +1042,6 @@ class Svir:
         selected_idx = layer_dict['selected_idx']
         proj_defs = layer_dict['proj_defs']
         project_definition = proj_defs[selected_idx]
-        if 'title' in project_definition:
-            project_title = project_definition['title']
-        else:
-            project_title = None
 
         QgsVectorFileWriter.writeAsVectorFormat(
             self.current_layer,
@@ -1051,7 +1056,8 @@ class Svir:
         # convert bytes to MB
         file_size_mb = file_size_mb / 1024 / 1024
 
-        dlg = UploadSettingsDialog(file_size_mb, self.iface, project_title)
+        dlg = UploadSettingsDialog(
+            file_size_mb, self.iface, project_definition)
         if dlg.exec_():
             project_definition['title'] = dlg.ui.title_le.text()
             zone_label_field = dlg.ui.zone_label_field_cbx.currentText()
@@ -1063,13 +1069,33 @@ class Svir:
             license_txt = '%s (%s)' % (license_name, license_url)
             project_definition['license'] = license_txt
             project_definition['svir_plugin_version'] = SVIR_PLUGIN_VERSION
-            if DEBUG:
-                print 'xml_file:', xml_file
-            write_iso_metadata_file(xml_file,
-                                    project_definition)
-            metadata_dialog = UploadMetadataDialog(
-                self.iface, file_stem)
-            if metadata_dialog.exec_():
-                QDesktopServices.openUrl(QUrl(metadata_dialog.layer_url))
-            elif DEBUG:
-                print "metadata_dialog cancelled"
+            if 'platform_layer_id' in project_definition:
+                with WaitCursorManager(
+                        'Updating project on the OpenQuake Platform',
+                        self.iface):
+                    hostname, username, password = get_credentials(self.iface)
+                    session = Session()
+                    platform_login(hostname, username, password, session)
+                    response = update_platform_project(
+                        hostname, session, project_definition)
+                    if response.ok:
+                        self.iface.messageBar().pushMessage(
+                            tr("Info"),
+                            tr(response.text),
+                            level=QgsMessageBar.INFO)
+                    else:
+                        self.iface.messageBar().pushMessage(
+                            tr("Error"),
+                            tr(response.text),
+                            level=QgsMessageBar.CRITICAL)
+            else:
+                if DEBUG:
+                    print 'xml_file:', xml_file
+                write_iso_metadata_file(xml_file,
+                                        project_definition)
+                metadata_dialog = UploadMetadataDialog(
+                    self.iface, file_stem)
+                if metadata_dialog.exec_():
+                    QDesktopServices.openUrl(QUrl(metadata_dialog.layer_url))
+                elif DEBUG:
+                    print "metadata_dialog cancelled"

--- a/ui/ui_upload_settings.py
+++ b/ui/ui_upload_settings.py
@@ -2,7 +2,7 @@
 
 # Form implementation generated from reading ui file 'ui/ui_upload_settings.ui'
 #
-# Created: Fri Mar  6 11:24:15 2015
+# Created: Tue May  5 11:35:42 2015
 #      by: PyQt4 UI code generator 4.10.4
 #
 # WARNING! All changes made in this file will be lost!
@@ -26,12 +26,16 @@ except AttributeError:
 class Ui_UploadSettingsDialog(object):
     def setupUi(self, UploadSettingsDialog):
         UploadSettingsDialog.setObjectName(_fromUtf8("UploadSettingsDialog"))
-        UploadSettingsDialog.resize(454, 265)
+        UploadSettingsDialog.resize(509, 265)
         self.verticalLayout = QtGui.QVBoxLayout(UploadSettingsDialog)
         self.verticalLayout.setObjectName(_fromUtf8("verticalLayout"))
         self.head_msg_lbl = QtGui.QLabel(UploadSettingsDialog)
         self.head_msg_lbl.setObjectName(_fromUtf8("head_msg_lbl"))
         self.verticalLayout.addWidget(self.head_msg_lbl)
+        self.update_chk = QtGui.QCheckBox(UploadSettingsDialog)
+        self.update_chk.setEnabled(False)
+        self.update_chk.setObjectName(_fromUtf8("update_chk"))
+        self.verticalLayout.addWidget(self.update_chk)
         self.formLayout = QtGui.QFormLayout()
         self.formLayout.setFieldGrowthPolicy(QtGui.QFormLayout.AllNonFixedFieldsGrow)
         self.formLayout.setObjectName(_fromUtf8("formLayout"))
@@ -79,7 +83,8 @@ class Ui_UploadSettingsDialog(object):
     def retranslateUi(self, UploadSettingsDialog):
         UploadSettingsDialog.setWindowTitle(_translate("UploadSettingsDialog", "Upload Settings", None))
         self.head_msg_lbl.setText(_translate("UploadSettingsDialog", "The active layer will be uploaded to the Openquake Platform", None))
-        self.label_4.setText(_translate("UploadSettingsDialog", "Project title", None))
+        self.update_chk.setText(_translate("UploadSettingsDialog", "Update the existing project on the Platform", None))
+        self.label_4.setText(_translate("UploadSettingsDialog", "Project definition title", None))
         self.label.setText(_translate("UploadSettingsDialog", "Zone labels field", None))
         self.label_6.setText(_translate("UploadSettingsDialog", "License", None))
         self.license_info_btn.setText(_translate("UploadSettingsDialog", "Info", None))

--- a/ui/ui_upload_settings.ui
+++ b/ui/ui_upload_settings.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>454</width>
+    <width>509</width>
     <height>265</height>
    </rect>
   </property>
@@ -22,6 +22,16 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="update_chk">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>Update the existing project on the Platform</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <layout class="QFormLayout" name="formLayout">
      <property name="fieldGrowthPolicy">
       <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
@@ -29,7 +39,7 @@
      <item row="0" column="0">
       <widget class="QLabel" name="label_4">
        <property name="text">
-        <string>Project title</string>
+        <string>Project definition title</string>
        </property>
       </widget>
      </item>

--- a/upload_metadata_dialog.py
+++ b/upload_metadata_dialog.py
@@ -43,7 +43,10 @@ from ui.ui_upload_metadata import Ui_UploadMetadataDialog
 from utils import (get_credentials,
                    platform_login,
                    upload_shp,
-                   create_progress_message_bar, clear_progress_message_bar)
+                   create_progress_message_bar,
+                   clear_progress_message_bar,
+                   SvNetworkError,
+                   )
 from shared import DEBUG
 
 
@@ -97,7 +100,14 @@ class UploadMetadataDialog(QDialog):
         self.upload()
 
     def upload(self):
-        self._login_to_platform()
+        try:
+            self._login_to_platform()
+        except SvNetworkError as e:
+            error_msg = (
+                'Unable to login to the platform: ' + e.message)
+            self.message_bar.pushMessage(
+                'Error', error_msg, level=QgsMessageBar.CRITICAL)
+            return
 
         # adding by emitting signal in different thread
         self.uploadThread = UploaderThread(

--- a/upload_settings_dialog.py
+++ b/upload_settings_dialog.py
@@ -95,10 +95,14 @@ class UploadSettingsDialog(QDialog):
         self.set_head_msg()
 
     def set_head_msg(self):
-        self.head_msg_update = (
-            'The current project definition will be added to the '
-            'OpenQuake Platform project\nidentified as "%s"'
-            % self.project_definition['platform_layer_id'])
+        if 'platform_layer_id' in self.project_definition:
+            platform_layer_id = self.project_definition['platform_layer_id']
+            self.head_msg_update = (
+                'The current project definition will be added to the '
+                'OpenQuake Platform project\nidentified as "%s"'
+                % platform_layer_id)
+        else:
+            self.head_msg_update = ''
         self.head_msg_new = (
             'The project will be uploaded to the OpenQuake Platform.'
             '\n\n(About %s MB of data will be transmitted)'

--- a/upload_settings_dialog.py
+++ b/upload_settings_dialog.py
@@ -48,32 +48,65 @@ class UploadSettingsDialog(QDialog):
     licenses. The user must click on a confirmation checkbox, before the
     uploading of the layer can be started.
     """
-    def __init__(self, upload_size, iface, project_title=None):
+    def __init__(self, upload_size, iface, project_definition):
         QDialog.__init__(self)
         # Set up the user interface from Designer.
         self.ui = Ui_UploadSettingsDialog()
         self.ui.setupUi(self)
         self.ok_button = self.ui.buttonBox.button(QDialogButtonBox.Ok)
         self.ok_button.setEnabled(False)
-        head_msg = ('The active layer and the current Project Definition'
-                    ' will be uploaded to the Openquake Platform.\n\n'
-                    '(About %s MB of data will be transmitted)'
-                    % upload_size)
-        self.ui.head_msg_lbl.setText(head_msg)
-        if project_title:
-            self.ui.title_le.setText(project_title)
+        self.upload_size = upload_size
+        self.project_definition = project_definition
+        if 'title' in self.project_definition:
+            self.ui.title_le.setText(self.project_definition['title'])
         else:
             self.ui.title_le.setText(DEFAULTS['ISO19115_TITLE'])
 
-        # if no field is selected, whe should not allow uploading
+        # if no field is selected, we should not allow uploading
         self.zone_label_field_is_specified = False
         reload_attrib_cbx(
             self.ui.zone_label_field_cbx, iface.activeLayer(), True)
+        # pre-select the field if it's specified in the project definition
+        if 'zone_label_field' in self.project_definition:
+            zone_label_idx = self.ui.zone_label_field_cbx.findText(
+                self.project_definition['zone_label_field'])
+            if zone_label_idx != -1:
+                self.ui.zone_label_field_cbx.setCurrentIndex(zone_label_idx)
+                self.zone_label_field_is_specified = True
 
         for license, link in LICENSES:
             self.ui.license_cbx.addItem(license, link)
-        self.ui.license_cbx.setCurrentIndex(
-            self.ui.license_cbx.findText(DEFAULT_LICENSE[0]))
+        if 'license' in self.project_definition:
+            license = self.project_definition['license'].split('(')[0].strip()
+            license_idx = self.ui.license_cbx.findText(license)
+            if license_idx != -1:
+                self.ui.license_cbx.setCurrentIndex(license_idx)
+            else:
+                self.ui.license_cbx.setCurrentIndex(
+                    self.ui.license_cbx.findText(DEFAULT_LICENSE[0]))
+        else:
+            self.ui.license_cbx.setCurrentIndex(
+                self.ui.license_cbx.findText(DEFAULT_LICENSE[0]))
+
+        self.ui.update_chk.setEnabled(
+            'platform_layer_id' in self.project_definition)
+        self.ui.update_chk.setChecked(
+            'platform_layer_id' in self.project_definition)
+        self.set_head_msg()
+
+    def set_head_msg(self):
+        self.head_msg_update = (
+            'The current project definition will be added to the '
+            'OpenQuake Platform project\nidentified as "%s"'
+            % self.project_definition['platform_layer_id'])
+        self.head_msg_new = (
+            'The project will be uploaded to the OpenQuake Platform.'
+            '\n\n(About %s MB of data will be transmitted)'
+            % self.upload_size)
+        if self.ui.update_chk.isChecked():
+            self.ui.head_msg_lbl.setText(self.head_msg_update)
+        else:
+            self.ui.head_msg_lbl.setText(self.head_msg_new)
 
     def set_ok_button(self):
         self.ok_button.setEnabled(
@@ -85,6 +118,10 @@ class UploadSettingsDialog(QDialog):
         zone_label_field = self.ui.zone_label_field_cbx.currentText()
         self.zone_label_field_is_specified = (zone_label_field != '')
         self.set_ok_button()
+
+    @pyqtSlot(int)
+    def on_update_chk_stateChanged(self):
+        self.set_head_msg()
 
     @pyqtSlot(int)
     def on_confirm_chk_stateChanged(self):

--- a/utils.py
+++ b/utils.py
@@ -251,6 +251,17 @@ def platform_login(host, username, password, session):
         raise SvNetworkError(error_message)
 
 
+def update_platform_project(host, session, project_definition):
+    proj_def_str = json.dumps(project_definition,
+                              sort_keys=False,
+                              indent=2,
+                              separators=(',', ': '))
+    payload = {'layer_name': project_definition['platform_layer_id'],
+               'project_definition': proj_def_str}
+    resp = session.post(host + '/svir/add_project_definition', data=payload)
+    return resp
+
+
 def upload_shp(host, session, file_stem, username):
     files = {'layer_title': file_stem,
              'base_file': ('%s.shp' % file_stem,

--- a/utils.py
+++ b/utils.py
@@ -247,7 +247,7 @@ def platform_login(host, username, password, session):
                                 )
     if session_resp.status_code != 200:  # 200 means successful:OK
         error_message = ('Unable to get session for login: %s' %
-                         session_resp.content)
+                         session_resp.text)
         raise SvNetworkError(error_message)
 
 


### PR DESCRIPTION
This PR completes the loop between the QGIS plugin and the web viewer.
When a project is loaded from the platform, the platform layer's id is saved into the project definitions. This information is retrieved when the user chooses to upload a project to the platform. In such situation, the user can decide to upload the current work as a new project (creating a new geonode layer) or to use the saved layer's id to update the corresponding project on the platform. The updating procedure uses the same API we made to allow the web viewer to append new project definitions into existing projects.