### PR TITLE
Simplify editing project definition title and description

### DIFF
--- a/svir.py
+++ b/svir.py
@@ -166,10 +166,10 @@ class Svir:
                            enable=False,
                            add_to_layer_actions=True)
         # Action to manage the projects
-        self.add_menu_item("projects_manager",
+        self.add_menu_item("project_definitions_manager",
                            ":/plugins/svir/copy.svg",
-                           u"Projects &manager",
-                           self.projects_manager,
+                           u"&Manage project definitions",
+                           self.project_definitions_manager,
                            enable=False,
                            add_to_layer_actions=True)
 
@@ -315,7 +315,8 @@ class Svir:
             # Activate actions which require a vector layer to be selected
             if self.current_layer.type() != QgsMapLayer.VectorLayer:
                 raise AttributeError
-            self.registered_actions["projects_manager"].setEnabled(True)
+            self.registered_actions[
+                "project_definitions_manager"].setEnabled(True)
             self.registered_actions["weight_data"].setEnabled(True)
             self.registered_actions["transform_attribute"].setEnabled(True)
             self.sync_proj_def()
@@ -334,7 +335,8 @@ class Svir:
             self.registered_actions["transform_attribute"].setEnabled(False)
             self.registered_actions["weight_data"].setEnabled(False)
             self.registered_actions["upload"].setEnabled(False)
-            self.registered_actions["projects_manager"].setEnabled(False)
+            self.registered_actions[
+                "project_definitions_manager"].setEnabled(False)
 
     def unload(self):
         # Remove the plugin menu items and toolbar icons
@@ -645,7 +647,7 @@ class Svir:
         self.update_actions_status()
         # in case of multiple project definitions, let the user select one
         if len(project_definitions) > 1:
-            self.projects_manager()
+            self.project_definitions_manager()
 
     @staticmethod
     def _add_new_theme(svi_themes,
@@ -669,7 +671,7 @@ class Svir:
         new_indicator['level'] = level
         svi_themes[theme_position]['children'].append(new_indicator)
 
-    def projects_manager(self):
+    def project_definitions_manager(self):
         self.sync_proj_def()
         select_proj_def_dlg = ProjectsManagerDialog(self.iface)
         if select_proj_def_dlg.exec_():

--- a/svir.py
+++ b/svir.py
@@ -643,6 +643,9 @@ class Svir:
         # project definition
         if not isinstance(project_definitions, list):
             project_definitions = [project_definitions]
+        for proj_def in project_definitions:
+            if 'platform_layer_id' not in proj_def:
+                proj_def['platform_layer_id'] = parent_dlg.layer_id
         self.update_proj_defs(layer.id(), project_definitions)
         self.update_actions_status()
         # in case of multiple project definitions, let the user select one

--- a/ui/ui_projects_manager_dialog.py
+++ b/ui/ui_projects_manager_dialog.py
@@ -2,7 +2,7 @@
 
 # Form implementation generated from reading ui file 'ui/ui_projects_manager_dialog.ui'
 #
-# Created: Tue Apr 21 10:18:06 2015
+# Created: Wed May  6 17:13:11 2015
 #      by: PyQt4 UI code generator 4.10.4
 #
 # WARNING! All changes made in this file will be lost!
@@ -30,18 +30,9 @@ class Ui_ProjectsManagerDialog(object):
         ProjectsManagerDialog.setModal(True)
         self.gridLayout = QtGui.QGridLayout(ProjectsManagerDialog)
         self.gridLayout.setObjectName(_fromUtf8("gridLayout"))
-        self.buttonBox = QtGui.QDialogButtonBox(ProjectsManagerDialog)
-        self.buttonBox.setOrientation(QtCore.Qt.Horizontal)
-        self.buttonBox.setStandardButtons(QtGui.QDialogButtonBox.Cancel|QtGui.QDialogButtonBox.Ok)
-        self.buttonBox.setObjectName(_fromUtf8("buttonBox"))
-        self.gridLayout.addWidget(self.buttonBox, 5, 0, 1, 1)
         self.label = QtGui.QLabel(ProjectsManagerDialog)
         self.label.setObjectName(_fromUtf8("label"))
         self.gridLayout.addWidget(self.label, 0, 0, 1, 1)
-        self.proj_def_detail = QtGui.QTextEdit(ProjectsManagerDialog)
-        self.proj_def_detail.setReadOnly(False)
-        self.proj_def_detail.setObjectName(_fromUtf8("proj_def_detail"))
-        self.gridLayout.addWidget(self.proj_def_detail, 4, 0, 1, 1)
         self.horizontalLayout = QtGui.QHBoxLayout()
         self.horizontalLayout.setContentsMargins(-1, 0, -1, -1)
         self.horizontalLayout.setObjectName(_fromUtf8("horizontalLayout"))
@@ -52,6 +43,29 @@ class Ui_ProjectsManagerDialog(object):
         self.add_proj_def_btn.setObjectName(_fromUtf8("add_proj_def_btn"))
         self.horizontalLayout.addWidget(self.add_proj_def_btn)
         self.gridLayout.addLayout(self.horizontalLayout, 2, 0, 1, 1)
+        self.proj_def_title = QtGui.QLineEdit(ProjectsManagerDialog)
+        self.proj_def_title.setObjectName(_fromUtf8("proj_def_title"))
+        self.gridLayout.addWidget(self.proj_def_title, 10, 0, 1, 1)
+        self.label_2 = QtGui.QLabel(ProjectsManagerDialog)
+        self.label_2.setObjectName(_fromUtf8("label_2"))
+        self.gridLayout.addWidget(self.label_2, 9, 0, 1, 1)
+        self.label_3 = QtGui.QLabel(ProjectsManagerDialog)
+        self.label_3.setObjectName(_fromUtf8("label_3"))
+        self.gridLayout.addWidget(self.label_3, 11, 0, 1, 1)
+        self.buttonBox = QtGui.QDialogButtonBox(ProjectsManagerDialog)
+        self.buttonBox.setOrientation(QtCore.Qt.Horizontal)
+        self.buttonBox.setStandardButtons(QtGui.QDialogButtonBox.Cancel|QtGui.QDialogButtonBox.Ok)
+        self.buttonBox.setObjectName(_fromUtf8("buttonBox"))
+        self.gridLayout.addWidget(self.buttonBox, 15, 0, 1, 1)
+        self.proj_def_raw = QtGui.QPlainTextEdit(ProjectsManagerDialog)
+        self.proj_def_raw.setObjectName(_fromUtf8("proj_def_raw"))
+        self.gridLayout.addWidget(self.proj_def_raw, 14, 0, 1, 1)
+        self.proj_def_descr = QtGui.QPlainTextEdit(ProjectsManagerDialog)
+        self.proj_def_descr.setObjectName(_fromUtf8("proj_def_descr"))
+        self.gridLayout.addWidget(self.proj_def_descr, 12, 0, 1, 1)
+        self.label_4 = QtGui.QLabel(ProjectsManagerDialog)
+        self.label_4.setObjectName(_fromUtf8("label_4"))
+        self.gridLayout.addWidget(self.label_4, 13, 0, 1, 1)
 
         self.retranslateUi(ProjectsManagerDialog)
         QtCore.QObject.connect(self.buttonBox, QtCore.SIGNAL(_fromUtf8("accepted()")), ProjectsManagerDialog.accept)
@@ -59,12 +73,10 @@ class Ui_ProjectsManagerDialog(object):
         QtCore.QMetaObject.connectSlotsByName(ProjectsManagerDialog)
 
     def retranslateUi(self, ProjectsManagerDialog):
-        ProjectsManagerDialog.setWindowTitle(_translate("ProjectsManagerDialog", "Projects manager", None))
+        ProjectsManagerDialog.setWindowTitle(_translate("ProjectsManagerDialog", "Project definitions manager", None))
         self.label.setText(_translate("ProjectsManagerDialog", "Please select one of the available project definitions", None))
-        self.proj_def_detail.setHtml(_translate("ProjectsManagerDialog", "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/REC-html40/strict.dtd\">\n"
-"<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/css\">\n"
-"p, li { white-space: pre-wrap; }\n"
-"</style></head><body style=\" font-family:\'Ubuntu\'; font-size:11pt; font-weight:400; font-style:normal;\">\n"
-"<p style=\"-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><br /></p></body></html>", None))
         self.add_proj_def_btn.setText(_translate("ProjectsManagerDialog", "+", None))
+        self.label_2.setText(_translate("ProjectsManagerDialog", "Title", None))
+        self.label_3.setText(_translate("ProjectsManagerDialog", "Description", None))
+        self.label_4.setText(_translate("ProjectsManagerDialog", "Raw textual representation", None))
 

--- a/ui/ui_projects_manager_dialog.ui
+++ b/ui/ui_projects_manager_dialog.ui
@@ -11,40 +11,16 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Projects manager</string>
+   <string>Project definitions manager</string>
   </property>
   <property name="modal">
    <bool>true</bool>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="5" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="0">
     <widget class="QLabel" name="label">
      <property name="text">
       <string>Please select one of the available project definitions</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QTextEdit" name="proj_def_detail">
-     <property name="readOnly">
-      <bool>false</bool>
-     </property>
-     <property name="html">
-      <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
     </widget>
    </item>
@@ -64,6 +40,46 @@ p, li { white-space: pre-wrap; }
       </widget>
      </item>
     </layout>
+   </item>
+   <item row="10" column="0">
+    <widget class="QLineEdit" name="proj_def_title"/>
+   </item>
+   <item row="9" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Title</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Description</string>
+     </property>
+    </widget>
+   </item>
+   <item row="15" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="0">
+    <widget class="QPlainTextEdit" name="proj_def_raw"/>
+   </item>
+   <item row="12" column="0">
+    <widget class="QPlainTextEdit" name="proj_def_descr"/>
+   </item>
+   <item row="13" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Raw textual representation</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
This PR adds to the "Project definitions manager" a "Title" line edit and a "Description" text edit, that dynamically update the corresponding fields in the selected project definition.
NOTE: the project definition's "Description" is a brief summary of that specific project definition, and does NOT correspond to the "Abstract", which instead describes the whole layer and that is stored into the GeoNode layer's metadata.