### PR TITLE
Add a button to the project manager, to make a copy of the selected project definition

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -34,6 +34,7 @@ changelog=
     * Primary indicators' labels rendered on the right of the D3 tree to avoid overlapping
     * When downloading a layer from the OQ-Platform, get the "supplemental information" leveraging the ad-hoc API
     * More readable project's details while browsing OQ-Platform's layers
+    * In the project manager it is possible to make a copy of the currently selected project definition
 
 # tags are comma separated with spaces allowed
 tags=GEM, SVIR, OpenQuake, Social Vulnerability, Integrated Risk

--- a/projects_manager_dialog.py
+++ b/projects_manager_dialog.py
@@ -179,9 +179,11 @@ class ProjectsManagerDialog(QDialog):
     @pyqtSlot()
     def on_proj_def_raw_textChanged(self):
         try:
-            project_definition = self.ui.proj_def_raw.toPlainText()
-            self.project_definitions['proj_defs'][
-                self.selected_idx] = json.loads(project_definition)
+            project_definition_str = self.ui.proj_def_raw.toPlainText()
+            project_definition = json.loads(project_definition_str)
+            self.project_definitions['proj_defs'][self.selected_idx] = \
+                project_definition
+            self.selected_proj_def = project_definition
             self.ok_button.setEnabled(True)
         except ValueError as e:
             print e

--- a/projects_manager_dialog.py
+++ b/projects_manager_dialog.py
@@ -120,14 +120,13 @@ class ProjectsManagerDialog(QDialog):
                                   separators=(',', ': '))
         self.ui.proj_def_raw.setPlainText(proj_def_str)
 
-    def add_proj_def(self, title):
-        proj_def_template = PROJECT_TEMPLATE
-        proj_def_template['title'] = title
+    def add_proj_def(self, title, proj_def=PROJECT_TEMPLATE):
+        proj_def['title'] = title
         if self.platform_layer_id:
-            proj_def_template['platform_layer_id'] = self.platform_layer_id
+            proj_def['platform_layer_id'] = self.platform_layer_id
         if self.zone_label_field:
-            proj_def_template['zone_label_field'] = self.zone_label_field
-        self.project_definitions['proj_defs'].append(proj_def_template)
+            proj_def['zone_label_field'] = self.zone_label_field
+        self.project_definitions['proj_defs'].append(proj_def)
         self.project_definitions['selected_idx'] = len(
             self.project_definitions['proj_defs']) - 1
         self.populate_proj_def_cbx()
@@ -157,6 +156,18 @@ class ProjectsManagerDialog(QDialog):
         self.update_proj_def_title()
         self.update_proj_def_descr()
         self.display_proj_def_raw()
+
+    @pyqtSlot()
+    def on_clone_btn_clicked(self):
+        title = (self.selected_proj_def['title'] + ' (copy)'
+                 if 'title' in self.selected_proj_def
+                 else '(copy)')
+        title, ok = QInputDialog().getText(self,
+                                           tr('Assign a title'),
+                                           tr('Project definition title'),
+                                           text=title)
+        if ok:
+            self.add_proj_def(title, self.selected_proj_def)
 
     @pyqtSlot()
     def on_add_proj_def_btn_clicked(self):

--- a/ui/ui_projects_manager_dialog.py
+++ b/ui/ui_projects_manager_dialog.py
@@ -2,7 +2,7 @@
 
 # Form implementation generated from reading ui file 'ui/ui_projects_manager_dialog.ui'
 #
-# Created: Wed May  6 17:13:11 2015
+# Created: Tue Jun 23 14:35:28 2015
 #      by: PyQt4 UI code generator 4.10.4
 #
 # WARNING! All changes made in this file will be lost!
@@ -66,6 +66,9 @@ class Ui_ProjectsManagerDialog(object):
         self.label_4 = QtGui.QLabel(ProjectsManagerDialog)
         self.label_4.setObjectName(_fromUtf8("label_4"))
         self.gridLayout.addWidget(self.label_4, 13, 0, 1, 1)
+        self.clone_btn = QtGui.QPushButton(ProjectsManagerDialog)
+        self.clone_btn.setObjectName(_fromUtf8("clone_btn"))
+        self.gridLayout.addWidget(self.clone_btn, 3, 0, 1, 1)
 
         self.retranslateUi(ProjectsManagerDialog)
         QtCore.QObject.connect(self.buttonBox, QtCore.SIGNAL(_fromUtf8("accepted()")), ProjectsManagerDialog.accept)
@@ -79,4 +82,5 @@ class Ui_ProjectsManagerDialog(object):
         self.label_2.setText(_translate("ProjectsManagerDialog", "Title", None))
         self.label_3.setText(_translate("ProjectsManagerDialog", "Description", None))
         self.label_4.setText(_translate("ProjectsManagerDialog", "Raw textual representation", None))
+        self.clone_btn.setText(_translate("ProjectsManagerDialog", "Make a copy", None))
 

--- a/ui/ui_projects_manager_dialog.py
+++ b/ui/ui_projects_manager_dialog.py
@@ -2,7 +2,7 @@
 
 # Form implementation generated from reading ui file 'ui/ui_projects_manager_dialog.ui'
 #
-# Created: Tue Jun 23 14:35:28 2015
+# Created: Tue Jun 23 15:18:54 2015
 #      by: PyQt4 UI code generator 4.10.4
 #
 # WARNING! All changes made in this file will be lost!
@@ -82,5 +82,5 @@ class Ui_ProjectsManagerDialog(object):
         self.label_2.setText(_translate("ProjectsManagerDialog", "Title", None))
         self.label_3.setText(_translate("ProjectsManagerDialog", "Description", None))
         self.label_4.setText(_translate("ProjectsManagerDialog", "Raw textual representation", None))
-        self.clone_btn.setText(_translate("ProjectsManagerDialog", "Make a copy", None))
+        self.clone_btn.setText(_translate("ProjectsManagerDialog", "Make a copy of the selected project definition", None))
 

--- a/ui/ui_projects_manager_dialog.ui
+++ b/ui/ui_projects_manager_dialog.ui
@@ -81,6 +81,13 @@
      </property>
     </widget>
    </item>
+   <item row="3" column="0">
+    <widget class="QPushButton" name="clone_btn">
+     <property name="text">
+      <string>Make a copy of the selected project definition</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <resources/>


### PR DESCRIPTION
Based on https://github.com/gem/oq-svir-qgis/pull/65

In addition to the new button for cloning a project definition, this PR fixes a bug in the form for updating the current project definition. Now, when the raw text is modified, the current project definition is updated, before it can be overwritten by changing the title or description.