### PR TITLE
Add a dropdown menu to select the field to be used for styling the layer

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -34,6 +34,7 @@ changelog=
     * Primary indicators' labels rendered on the right of the D3 tree to avoid overlapping
     * When downloading a layer from the OQ-Platform, get the "supplemental information" leveraging the ad-hoc API
     * More readable project's details while browsing OQ-Platform's layers
+    * From the weighting dialog it is possible to select the field to be used to style the layer
 
 # tags are comma separated with spaces allowed
 tags=GEM, SVIR, OpenQuake, Social Vulnerability, Integrated Risk

--- a/svir.py
+++ b/svir.py
@@ -843,7 +843,7 @@ class Svir:
             self.recalculate_indexes(data)
         dlg.added_attrs_ids.update(added_attrs_ids)
         dlg.discarded_feats = discarded_feats
-        dlg.project_definition = deepcopy(project_definition)
+        dlg.update_project_definition(project_definition)
         self.redraw_ir_layer(project_definition)
 
     def recalculate_indexes(self, data):
@@ -964,21 +964,29 @@ class Svir:
         return True
 
     def redraw_ir_layer(self, data):
+        # if the user has explicitly selected a field to use for styling, use
+        # it, otherwise attempt to show the IRI, or the SVI, or the RI
+        if 'style_by_field' in data:
+            target_field = data['style_by_field']
+            printing_str = target_field
         # if an IRI has been already calculated, show it
-        # else show the SVI, else RI
-        if self.is_iri_renderable(data):
-            target_field = data['field']
+        elif self.is_iri_renderable(data):
+            iri_node = data
+            target_field = iri_node['field']
             printing_str = 'IRI'
+        # else show the SVI if possible
         elif self.is_svi_renderable(data):
             svi_node = data['children'][1]
             target_field = svi_node['field']
             printing_str = 'SVI'
+        # otherwise attempt to show the RI
         elif self.is_ri_renderable(data):
             ri_node = data['children'][0]
             target_field = ri_node['field']
             printing_str = 'RI'
-        else:
+        else:  # if none of them can be rendered, then do nothing
             return
+        # proceed only if the target field is actually a field of the layer
         if self.current_layer.fieldNameIndex(target_field) == -1:
             return
         if DEBUG:

--- a/ui/ui_weight_data.py
+++ b/ui/ui_weight_data.py
@@ -2,7 +2,7 @@
 
 # Form implementation generated from reading ui file 'ui/ui_weight_data.ui'
 #
-# Created: Wed Jan 14 12:08:46 2015
+# Created: Tue Jun 23 16:32:43 2015
 #      by: PyQt4 UI code generator 4.10.4
 #
 # WARNING! All changes made in this file will be lost!
@@ -31,14 +31,20 @@ class Ui_WeightDataDialog(object):
         WeightDataDialog.setModal(True)
         self.gridLayout = QtGui.QGridLayout(WeightDataDialog)
         self.gridLayout.setObjectName(_fromUtf8("gridLayout"))
+        self.web_view = QtWebKit.QWebView(WeightDataDialog)
+        self.web_view.setObjectName(_fromUtf8("web_view"))
+        self.gridLayout.addWidget(self.web_view, 0, 0, 1, 1)
+        self.label = QtGui.QLabel(WeightDataDialog)
+        self.label.setObjectName(_fromUtf8("label"))
+        self.gridLayout.addWidget(self.label, 1, 0, 1, 1)
         self.buttonBox = QtGui.QDialogButtonBox(WeightDataDialog)
         self.buttonBox.setOrientation(QtCore.Qt.Horizontal)
         self.buttonBox.setStandardButtons(QtGui.QDialogButtonBox.Cancel|QtGui.QDialogButtonBox.Ok)
         self.buttonBox.setObjectName(_fromUtf8("buttonBox"))
-        self.gridLayout.addWidget(self.buttonBox, 1, 0, 1, 1)
-        self.web_view = QtWebKit.QWebView(WeightDataDialog)
-        self.web_view.setObjectName(_fromUtf8("web_view"))
-        self.gridLayout.addWidget(self.web_view, 0, 0, 1, 1)
+        self.gridLayout.addWidget(self.buttonBox, 3, 0, 1, 1)
+        self.style_by_field_cbx = QtGui.QComboBox(WeightDataDialog)
+        self.style_by_field_cbx.setObjectName(_fromUtf8("style_by_field_cbx"))
+        self.gridLayout.addWidget(self.style_by_field_cbx, 2, 0, 1, 1)
 
         self.retranslateUi(WeightDataDialog)
         QtCore.QObject.connect(self.buttonBox, QtCore.SIGNAL(_fromUtf8("accepted()")), WeightDataDialog.accept)
@@ -47,5 +53,6 @@ class Ui_WeightDataDialog(object):
 
     def retranslateUi(self, WeightDataDialog):
         WeightDataDialog.setWindowTitle(_translate("WeightDataDialog", "Weight Data", None))
+        self.label.setText(_translate("WeightDataDialog", "Style the layer by", None))
 
 from PyQt4 import QtWebKit

--- a/ui/ui_weight_data.ui
+++ b/ui/ui_weight_data.ui
@@ -20,7 +20,17 @@
    <bool>true</bool>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QWebView" name="web_view" native="true"/>
+   </item>
    <item row="1" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Style the layer by</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -30,8 +40,8 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QWebView" name="web_view" native="true"/>
+   <item row="2" column="0">
+    <widget class="QComboBox" name="style_by_field_cbx"/>
    </item>
   </layout>
  </widget>

--- a/utils.py
+++ b/utils.py
@@ -89,6 +89,19 @@ def get_node(sub_tree, name):
     return None  # not found
 
 
+def get_field_names(sub_tree, field_names):
+    # return a list of all the field names defined in the project definition
+    # (browsing the tree recursively)
+    # field_names is an accumulator that needs to be passed as []
+    if 'field' in sub_tree:
+        field_names.append(sub_tree['field'])
+    if 'children' in sub_tree:
+        for child in sub_tree['children']:
+            child_field_names = get_field_names(child, field_names)
+            field_names.extend(child_field_names)
+    return field_names
+
+
 def get_credentials(iface):
     qs = QSettings()
     hostname = qs.value('svir/platform_hostname', '')

--- a/utils.py
+++ b/utils.py
@@ -89,10 +89,12 @@ def get_node(sub_tree, name):
     return None  # not found
 
 
-def get_field_names(sub_tree, field_names):
+def get_field_names(sub_tree, field_names=None):
     # return a list of all the field names defined in the project definition
-    # (browsing the tree recursively)
-    # field_names is an accumulator that needs to be passed as []
+    # field_names is an accumulator that is extended browsing the tree
+    # recursively
+    if field_names is None:
+        field_names = []
     if 'field' in sub_tree:
         field_names.append(sub_tree['field'])
     if 'children' in sub_tree:

--- a/weight_data_dialog.py
+++ b/weight_data_dialog.py
@@ -74,7 +74,7 @@ class WeightDataDialog(QDialog):
         self.discarded_feats = set()
         self.any_changes_made = False
         self.active_layer_numeric_fields = []
-        self.set_active_layer_numeric_fields()
+        self.update_active_layer_numeric_fields()
 
         self.project_definition = deepcopy(project_definition)
         try:
@@ -100,14 +100,14 @@ class WeightDataDialog(QDialog):
         self.project_definition = deepcopy(project_definition)
         self.populate_style_by_field_cbx()
 
-    def set_active_layer_numeric_fields(self):
+    def update_active_layer_numeric_fields(self):
         self.active_layer_numeric_fields = [
             field.name()
             for field in self.iface.activeLayer().dataProvider().fields()
             if field.typeName() in NUMERIC_FIELD_TYPES]
 
     def populate_style_by_field_cbx(self):
-        self.set_active_layer_numeric_fields()
+        self.update_active_layer_numeric_fields()
         fields_in_proj_def = get_field_names(self.project_definition)
         fields_for_styling = [
             field for field in self.active_layer_numeric_fields

--- a/weight_data_dialog.py
+++ b/weight_data_dialog.py
@@ -31,7 +31,9 @@ from PyQt4.QtCore import (Qt,
                           QUrl,
                           QSettings,
                           pyqtProperty,
-                          pyqtSignal)
+                          pyqtSignal,
+                          pyqtSlot,
+                          )
 
 from PyQt4.QtGui import (QDialog,
                          QDialogButtonBox)
@@ -44,6 +46,7 @@ from shared import (DEFAULT_OPERATOR,
                     NUMERIC_FIELD_TYPES,
                     NODE_TYPES,
                     DEBUG)
+from utils import get_field_names
 
 
 class WeightDataDialog(QDialog):
@@ -70,12 +73,14 @@ class WeightDataDialog(QDialog):
         self.added_attrs_ids = set()
         self.discarded_feats = set()
         self.any_changes_made = False
+        self.active_layer_numeric_fields = []
+        self.set_active_layer_numeric_fields()
 
         self.project_definition = deepcopy(project_definition)
         try:
             proj_title = self.project_definition['title']
         except KeyError:
-            proj_title = 'Untitled'
+            proj_title = 'untitled'
         dialog_title = (
             'Set weights and operators for project: "%s"' % proj_title)
         self.setWindowTitle(dialog_title)
@@ -89,11 +94,37 @@ class WeightDataDialog(QDialog):
         self.frame.javaScriptWindowObjectCleared.connect(self.setup_js)
         self.web_view.loadFinished.connect(self.show_tree)
         self.json_updated.connect(self.handle_json_updated)
+        self.populate_style_by_field_cbx()
 
+    def update_project_definition(self, project_definition):
+        self.project_definition = deepcopy(project_definition)
+        self.populate_style_by_field_cbx()
+
+    def set_active_layer_numeric_fields(self):
         self.active_layer_numeric_fields = [
             field.name()
-            for field in iface.activeLayer().dataProvider().fields()
+            for field in self.iface.activeLayer().dataProvider().fields()
             if field.typeName() in NUMERIC_FIELD_TYPES]
+
+    def populate_style_by_field_cbx(self):
+        self.set_active_layer_numeric_fields()
+        # the empty list will be filled by get_field_names
+        fields_in_proj_def = get_field_names(self.project_definition, [])
+        fields_for_styling = [
+            field for field in self.active_layer_numeric_fields
+            if field in fields_in_proj_def]
+        # block signals to avoid performing the onchange actions while adding
+        # items programmatically
+        self.ui.style_by_field_cbx.blockSignals(True)
+        self.ui.style_by_field_cbx.clear()
+        self.ui.style_by_field_cbx.addItem('')
+        self.ui.style_by_field_cbx.addItems(fields_for_styling)
+        if 'style_by_field' in self.project_definition:
+            idx = self.ui.style_by_field_cbx.findText(
+                self.project_definition['style_by_field'])
+            self.ui.style_by_field_cbx.setCurrentIndex(idx)
+        # reactivate the signals, so the user's changes will trigger something
+        self.ui.style_by_field_cbx.blockSignals(False)
 
     def setup_context_menu(self):
         settings = QSettings()
@@ -136,6 +167,15 @@ class WeightDataDialog(QDialog):
             if 'children' in element:
                 self.clean_json(element['children'])
         return data[0]
+
+    @pyqtSlot(str)
+    def on_style_by_field_cbx_currentIndexChanged(self):
+        if self.ui.style_by_field_cbx.currentText():
+            self.project_definition['style_by_field'] = \
+                self.ui.style_by_field_cbx.currentText()
+        elif 'style_by_field' in self.project_definition:
+            # if the empty item is selected, clean the project definition
+            del self.project_definition['style_by_field']
 
     @pyqtProperty(str)
     def json_str(self):

--- a/weight_data_dialog.py
+++ b/weight_data_dialog.py
@@ -108,8 +108,7 @@ class WeightDataDialog(QDialog):
 
     def populate_style_by_field_cbx(self):
         self.set_active_layer_numeric_fields()
-        # the empty list will be filled by get_field_names
-        fields_in_proj_def = get_field_names(self.project_definition, [])
+        fields_in_proj_def = get_field_names(self.project_definition)
         fields_for_styling = [
             field for field in self.active_layer_numeric_fields
             if field in fields_in_proj_def]


### PR DESCRIPTION
Based on https://github.com/gem/oq-svir-qgis/pull/65

An additional dropdown menu is added to the weighting dialog, enabling the user to select which field should be used by the plugin to automatically style the layer. This makes possible, for instance, to quickly style the layer by one of the socioeconomic themes (that now are stored as fields in the layer).
If none is selected from this dropdown menu, the automatic behavior of the tool is the old one (check if it's possible to style by the IRI, otherwise attempt to style by the SVI, otherwise by the RI... or do nothing).