### PR TITLE
Fix a QGIS 2.10 issue with CSV import

### DIFF
--- a/import_sv_data.py
+++ b/import_sv_data.py
@@ -189,7 +189,6 @@ class SvDownloader(object):
                 msg_bar_item, progress = create_progress_message_bar(
                     message_bar, 'Downloading socioeconomic data...')
                 for line in result.iter_lines():
-
                     csv_file.write(line + '\n')
                     n_downloaded_countries += 1
                     progress.setValue(

--- a/svir.py
+++ b/svir.py
@@ -27,6 +27,8 @@ import json
 import os.path
 import tempfile
 import uuid
+import fileinput
+import re
 from copy import deepcopy
 
 from math import floor, ceil
@@ -528,6 +530,17 @@ class Svir:
         QgsMessageLog.logMessage(msg, 'GEM Social Vulnerability Downloader')
         # don't remove the file, otherwise there will be concurrency
         # problems
+
+        # fix an issue of QGIS 10, that is unable to read
+        # multipolygons if they contain spaces between two polygons.
+        # We remove those spaces from the csv file before importing it.
+        # TODO: Remove this as soon as QGIS solves that issue
+        for line in fileinput.input(fname, inplace=True):
+            line = re.sub('\)\),\s\(\(', ')),((', line.rstrip())
+            line = re.sub('\),\s\(', '),(', line.rstrip())
+            # thanks to inplace=True, 'print line' writes the line into the
+            # input file, overwriting the original line
+            print line
 
         # count top lines in the csv starting with '#'
         lines_to_skip_count = count_heading_commented_lines(fname)


### PR DESCRIPTION
QGIS 2.10 in unable to import multipolygons from CSV if there are whitespaces between polygons.
This quick fix removes those whitespaces before letting QGIS import the CSV.
Such change should be removed as soon as the bug will be fixed in QGIS.