### PR TITLE
Show a confirmation/warning dialog when pressing "cancel" or "close" in the weighting dialog

### DIFF
--- a/svir.py
+++ b/svir.py
@@ -828,7 +828,7 @@ class Svir:
             self.notify_added_attrs_and_discarded_feats(
                 dlg.added_attrs_ids, dlg.discarded_feats)
             self.update_actions_status()
-        else:  # 'cancel' was pressed
+        else:  # 'cancel' was pressed or the dialog was closed
             if sld_was_saved:  # was able to save the original style
                 self.iface.activeLayer().loadSldStyle(sld_file_name)
             # if any of the indices were saved before starting to edit the

--- a/utils.py
+++ b/utils.py
@@ -45,6 +45,20 @@ def tr(message):
     return QApplication.translate('Svir', message)
 
 
+def confirmation_on_close(parent, event=None):
+    msg = tr("WARNING: all unsaved changes will be lost. Are you sure?")
+    reply = QMessageBox.question(
+        parent, 'Message', msg, QMessageBox.Yes, QMessageBox.No)
+    if event is not None:
+        if reply == QMessageBox.Yes:
+            event.accept()
+        else:
+            event.ignore()
+    else:
+        if reply == QMessageBox.Yes:
+            parent.accept()
+
+
 def replace_fields(sub_tree_root, before, after):
     """
     Recursively search the project definition for 'field's equal to the

--- a/utils.py
+++ b/utils.py
@@ -56,7 +56,7 @@ def confirmation_on_close(parent, event=None):
             event.ignore()
     else:
         if reply == QMessageBox.Yes:
-            parent.accept()
+            parent.__class__.__base__.reject(parent)
 
 
 def replace_fields(sub_tree_root, before, after):

--- a/weight_data_dialog.py
+++ b/weight_data_dialog.py
@@ -36,7 +36,8 @@ from PyQt4.QtCore import (Qt,
                           )
 
 from PyQt4.QtGui import (QDialog,
-                         QDialogButtonBox)
+                         QDialogButtonBox,
+                         )
 from PyQt4.QtWebKit import QWebSettings
 
 from ui.ui_weight_data import Ui_WeightDataDialog
@@ -46,7 +47,7 @@ from shared import (DEFAULT_OPERATOR,
                     NUMERIC_FIELD_TYPES,
                     NODE_TYPES,
                     DEBUG)
-from utils import get_field_names
+from utils import get_field_names, confirmation_on_close
 
 
 class WeightDataDialog(QDialog):
@@ -95,6 +96,12 @@ class WeightDataDialog(QDialog):
         self.web_view.loadFinished.connect(self.show_tree)
         self.json_updated.connect(self.handle_json_updated)
         self.populate_style_by_field_cbx()
+
+    def closeEvent(self, event):
+        confirmation_on_close(self, event)
+
+    def reject(self):
+        confirmation_on_close(self)
 
     def update_project_definition(self, project_definition):
         self.project_definition = deepcopy(project_definition)


### PR DESCRIPTION
This is to avoid the user to accidentally close the weighting dialog, losing all the unsaved changes. The same can be easily re-used for other dialogs, but it doesn't look necessary elsewhere (so far) and it might be a little annoying for the user to be asked to confirm everywhere, so it has been implemented only for the weighting dialog.