### PR TITLE
Immediately style the layer by the selected field, even without closing the weighting dialog

### DIFF
--- a/weight_data_dialog.py
+++ b/weight_data_dialog.py
@@ -172,6 +172,7 @@ class WeightDataDialog(QDialog):
         elif 'style_by_field' in self.project_definition:
             # if the empty item is selected, clean the project definition
             del self.project_definition['style_by_field']
+        self.json_updated.emit(self.project_definition)
 
     @pyqtProperty(str)
     def json_str(self):


### PR DESCRIPTION
We noticed that changing the field by which we wanted to style the layer, did not immediately produce a change to the style. Changes were displayed from the second time it was switched. I investigated, and I found out it was due to the fact we were not emitting a signal to declare the project definition was changed, so the styling was not performed right away.
Emitting the json_updated signal, the change becomes immediately visible, so it is possible to keep the weighting dialog open while styling by different fields.
It is a one-line change, but it produces an important improvement to the user-experience.