### PR TITLE
Add checkbox to weighting dialog, to toggle on-the-fly calculations

### DIFF
--- a/ui/ui_weight_data.py
+++ b/ui/ui_weight_data.py
@@ -2,7 +2,7 @@
 
 # Form implementation generated from reading ui file 'ui/ui_weight_data.ui'
 #
-# Created: Mon Jul  6 11:34:11 2015
+# Created: Mon Aug  3 17:01:35 2015
 #      by: PyQt4 UI code generator 4.10.4
 #
 # WARNING! All changes made in this file will be lost!
@@ -51,10 +51,14 @@ class Ui_WeightDataDialog(object):
         self.buttonBox.setOrientation(QtCore.Qt.Horizontal)
         self.buttonBox.setStandardButtons(QtGui.QDialogButtonBox.Cancel|QtGui.QDialogButtonBox.Ok)
         self.buttonBox.setObjectName(_fromUtf8("buttonBox"))
-        self.gridLayout.addWidget(self.buttonBox, 3, 0, 1, 1)
+        self.gridLayout.addWidget(self.buttonBox, 4, 0, 1, 1)
         self.style_by_field_cbx = QtGui.QComboBox(WeightDataDialog)
         self.style_by_field_cbx.setObjectName(_fromUtf8("style_by_field_cbx"))
         self.gridLayout.addWidget(self.style_by_field_cbx, 2, 0, 1, 1)
+        self.on_the_fly_ckb = QtGui.QCheckBox(WeightDataDialog)
+        self.on_the_fly_ckb.setChecked(True)
+        self.on_the_fly_ckb.setObjectName(_fromUtf8("on_the_fly_ckb"))
+        self.gridLayout.addWidget(self.on_the_fly_ckb, 3, 0, 1, 1)
 
         self.retranslateUi(WeightDataDialog)
         QtCore.QObject.connect(self.buttonBox, QtCore.SIGNAL(_fromUtf8("accepted()")), WeightDataDialog.accept)
@@ -64,5 +68,6 @@ class Ui_WeightDataDialog(object):
     def retranslateUi(self, WeightDataDialog):
         WeightDataDialog.setWindowTitle(_translate("WeightDataDialog", "Weight Data", None))
         self.label.setText(_translate("WeightDataDialog", "Style the layer by", None))
+        self.on_the_fly_ckb.setText(_translate("WeightDataDialog", "Run calculations on-the-fly", None))
 
 from PyQt4 import QtWebKit

--- a/ui/ui_weight_data.ui
+++ b/ui/ui_weight_data.ui
@@ -43,7 +43,7 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="4" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -55,6 +55,16 @@
    </item>
    <item row="2" column="0">
     <widget class="QComboBox" name="style_by_field_cbx"/>
+   </item>
+   <item row="3" column="0">
+    <widget class="QCheckBox" name="on_the_fly_ckb">
+     <property name="text">
+      <string>Run calculations on-the-fly</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/weight_data_dialog.py
+++ b/weight_data_dialog.py
@@ -38,7 +38,6 @@ from PyQt4.QtCore import (Qt,
 from PyQt4.QtGui import (QDialog,
                          QDialogButtonBox,
                          )
-from PyQt4.QtWebKit import QWebSettings
 
 from ui.ui_weight_data import Ui_WeightDataDialog
 
@@ -150,8 +149,9 @@ class WeightDataDialog(QDialog):
             print 'in handle_json_updated, data='
             pp.pprint(data)
 
-        self.project_definition = self.clean_json([data])
-        self.json_cleaned.emit(self.project_definition)
+        if self.ui.on_the_fly_ckb.isChecked():
+            self.project_definition = self.clean_json([data])
+            self.json_cleaned.emit(self.project_definition)
 
     def clean_json(self, data):
         # this method takes a list of dictionaries and removes some unneeded


### PR DESCRIPTION
Addressing https://bugs.launchpad.net/oq-svir/+bug/1477029

While the user is building the project definition using the weighting dialog, the tool keeps recalculating the composite indices whenever any change is made to the model. The advantage of it is that the layer is styled dynamically, displaying in real-time the effects produced by each change. The drawback is that,
when a project is big, the re-calculations are time-consuming and therefore the weighting dialog becomes quite slow and not so responsive.
With this PR, a new checkbox is added to the dialog. It is checked by default, activating the on-the-fly calculations (the behavior of the tool before this PR). The user can uncheck it, preventing the tool from doing the re-calculations on-the-fly, therefore allowing to build the project definition much faster.