### PR TITLE
Count the active layer's vertices before uploading a project to the platform

### DIFF
--- a/process_layer.py
+++ b/process_layer.py
@@ -380,3 +380,49 @@ class ProcessLayer():
             return type_str in type_list
         else:
             return False
+
+    def count_vertices(self):
+        """
+        Inspired by "https://github.com/GeospatialEnablingTechnologies/
+                             GET-Qgis-plugins/blob/master/Vertices_Counter/
+                             Vertices_Counter.py"
+
+        Count the total number of vertices in the layer.
+        In DEBUG mode, also print vertices count for each single feature
+
+        :return: The total number of vertices in the layer
+        """
+        layer_vertices = 0
+        for feat in self.layer.getFeatures():
+            feature_vertices = 0
+            geom = feat.geometry()
+            geom_type = geom.type()
+            if geom_type == QGis.Polygon:
+                if geom.isMultipart():
+                    polygons = geom.asMultiPolygon()
+                else:
+                    polygons = [geom.asPolygon()]
+                for polygon in polygons:
+                    for ring in polygon:
+                        feature_vertices += len(ring)
+            elif geom_type == QGis.Line:
+                if geom.isMultipart():
+                    lines = geom.asMultiPolyline()
+                else:
+                    lines = [geom.asPolyline()]
+                for line in lines:
+                    feature_vertices += len(line)
+            elif geom_type == QGis.Point:
+                if geom.isMultipart():
+                    points = geom.asMultiPoint()
+                else:
+                    points = [geom.asPoint()]
+                for point in points:
+                    feature_vertices += 1
+            else:
+                raise TypeError(
+                    'Geometry type %s can not be accepted' % geom_type)
+            layer_vertices += feature_vertices
+            if DEBUG:
+                print "Feature %d, %d vertices" % (feat.id(), feature_vertices)
+        return layer_vertices

--- a/svir.py
+++ b/svir.py
@@ -1269,6 +1269,7 @@ class Svir:
             suppl_info['svir_plugin_version'] = SVIR_PLUGIN_VERSION
             suppl_info['supplemental_information_version'] = \
                 SUPPLEMENTAL_INFORMATION_VERSION
+            suppl_info['vertices_count'] = dlg.vertices_count
 
             suppl_info['project_definitions'][selected_idx] = \
                 project_definition

--- a/upload_settings_dialog.py
+++ b/upload_settings_dialog.py
@@ -30,7 +30,8 @@ from PyQt4.QtGui import (QDialog,
                          QDesktopServices)
 from ui.ui_upload_settings import Ui_UploadSettingsDialog
 from defaults import DEFAULTS
-from utils import reload_attrib_cbx, tr
+from process_layer import ProcessLayer
+from utils import reload_attrib_cbx, tr, WaitCursorManager
 
 LICENSES = (
     ('CC0', 'http://creativecommons.org/about/cc0'),
@@ -55,6 +56,7 @@ class UploadSettingsDialog(QDialog):
         self.ui.setupUi(self)
         self.ok_button = self.ui.buttonBox.button(QDialogButtonBox.Ok)
         self.ok_button.setEnabled(False)
+        self.vertices_count = None
         self.suppl_info = suppl_info
         selected_idx = self.suppl_info['selected_project_definition_idx']
         proj_defs = self.suppl_info['project_definitions']
@@ -82,6 +84,10 @@ class UploadSettingsDialog(QDialog):
         self.ui.update_radio.setEnabled(self.exists_on_platform)
         self.ui.update_radio.setChecked(self.exists_on_platform)
         self.set_labels()
+
+        with WaitCursorManager("Counting layer's vertices", iface):
+            self.vertices_count = ProcessLayer(
+                iface.activeLayer()).count_vertices()
 
     def set_zone_label_field(self):
         # pre-select the field if it's specified in the supplemental info

--- a/utils.py
+++ b/utils.py
@@ -511,7 +511,8 @@ class IterableToFileAdapter(object):
     """ an adapter which makes the multipart-generator issued by poster
         accessible to requests. Based upon code from
         http://stackoverflow.com/a/13911048/1659732
-        https://mazdermind.wordpress.com/2014/03/14/http-upload-with-progress-using-poster-and-requests/
+        https://mazdermind.wordpress.com/
+                2014/03/14/http-upload-with-progress-using-poster-and-requests/
     """
     def __init__(self, iterable):
         self.iterator = iter(iterable)


### PR DESCRIPTION
Based on https://github.com/gem/oq-svir-qgis/pull/83

We might want to set a maximum threshold for the complexity of geometries to be uploaded to the platform. With this PR, the vertices of the active layer's geometries are counted when the "upload" dialog is opened. This is still WIP, and we need to decide if and when we want to display the vertices count to the user, and if we want to forbid to upload something too complex or at least to display some kind of warning, also to inform the user that the web viewer will not be able to manage an exceedingly complex project.