### PR TITLE
Update GitHub Actions to download install.py  from the matching version branch

### DIFF
--- a/.github/workflows/qgis_ltr_engine_releases.yml
+++ b/.github/workflows/qgis_ltr_engine_releases.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         # NOTE: it would be better to point to lts and latest if possible
         # NOTE: checking also master to make sure risk workshop demos keep working also on master
-        ENGINE_BR: ['engine-3.23', 'engine-3.25', 'engine-3.26', 'master']  # NOTE: add latest when different from lts
+        ENGINE_BR: ['engine-3.23', 'engine-3.26', 'master']  # NOTE: add latest when different from lts
         # NOTE: we might test also for qgis/qgis:3.22 that is the version of qgis-server that we are currently using in the Geoviewer, but it currently causes a segfault
         # NOTE: qgis:stable points to the latest release, whereas qgis:latest points to qgis master
         # QGIS_DOCKER_VERSION: ['qgis/qgis:ltr', 'qgis/qgis:stable']

--- a/.github/workflows/qgis_ltr_engine_releases.yml
+++ b/.github/workflows/qgis_ltr_engine_releases.yml
@@ -67,7 +67,7 @@ jobs:
           IRMT_BR=$ENGINE_BR
           git fetch
           git checkout $IRMT_BR
-          curl -O https://raw.githubusercontent.com/gem/oq-engine/master/install.py
+          curl -O https://raw.githubusercontent.com/gem/oq-engine/${ENGINE_BR}/install.py
           ls -lrt install.py
           echo "Using branch ${ENGINE_BR}"
           if [ "$(git ls-remote --heads https://github.com/gem/oq-engine.git ${ENGINE_BR})" = "" ]; then

--- a/.github/workflows/test_push.yml
+++ b/.github/workflows/test_push.yml
@@ -73,7 +73,7 @@ jobs:
           if [ "$(git ls-remote --heads https://github.com/gem/oq-engine.git ${ENGINE_BR})" == "" ]; then
               ENGINE_BR='master';
           fi
-          curl -O https://raw.githubusercontent.com/gem/oq-engine/master/install.py
+          curl -O https://raw.githubusercontent.com/gem/oq-engine/${ENGINE_BR}/install.py
           ls -lrt install.py
           echo "Engine branch: ${ENGINE_BR}"
           python$PY_VER install.py user --version=${ENGINE_BR}


### PR DESCRIPTION
This PR updates the GitHub Actions workflow so that install.py are downloaded from the branch corresponding to the current version, instead of using master or default branch.

This ensures that the workflow always uses files that are consistent with the version being built or released.